### PR TITLE
1. Change the website footer section

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -104,7 +104,7 @@ onMounted(() => {
             </div>
 
         </div>
-        <p class="section-title copyright-note no-targetable"> &copy; 2024 Skylite Agency (project ownership: MTX) </p>
+        <p class="section-title copyright-note no-targetable"> &copy; 2024 Skylite Agency [ project ownership: MTX ] </p>
     </div>
 </template>
 


### PR DESCRIPTION
- As a first, test update, a footer copyright note has gotten a slight change - switching the brackets from curly to square ones. Also changed a year on copyright note from 2023 to 2024.